### PR TITLE
Spotテーブルのすべての地点とその国、動画を返すapiを追加

### DIFF
--- a/app/controllers/admin/spots_controller.rb
+++ b/app/controllers/admin/spots_controller.rb
@@ -62,7 +62,8 @@ class Admin::SpotsController < Admin::BaseController
       :name,
       :name_ens,
       :lat,
-      :lng
+      :lng,
+      :click_count
     )
   end
 end

--- a/app/controllers/api/v1/spots_controller.rb
+++ b/app/controllers/api/v1/spots_controller.rb
@@ -18,13 +18,16 @@ class Api::V1::SpotsController < ApiController
     render json: { status: 'ok' }
   end
 
-  # Spotテーブルのすべての地点とその国を返す
+  # Spotテーブルのすべての地点とその国、動画を返す
   def all_spot
     spots = Spot.all.order(click_count: :desc)
     areas = []
+    videos = []
     spots.each do |spot|
       areas << spot.country
+      ramdam_data = Video.where(spot: spot.name).order("RANDOM()").first
+      videos << { video_id: ramdam_data.video_id, title: ramdam_data.title, thumbnail: ramdam_data.thumbnail, view_count: ramdam_data.view_count.to_s(:delimited), published_at: ramdam_data.published_at.strftime("%Y/%m/%d") }
     end
-    render json: { spots: spots, areas: areas }
+    render json: { spots: spots, areas: areas, videos: videos }
   end
 end

--- a/app/controllers/api/v1/spots_controller.rb
+++ b/app/controllers/api/v1/spots_controller.rb
@@ -20,13 +20,19 @@ class Api::V1::SpotsController < ApiController
 
   # Spotテーブルのすべての地点とその国、動画を返す
   def all_spot
-    spots = Spot.all.order(click_count: :desc)
+    all_spots = Spot.all.order(click_count: :desc)
+    spots = []
     areas = []
     videos = []
-    spots.each do |spot|
-      areas << spot.country
-      ramdam_data = Video.where(spot: spot.name).order("RANDOM()").first
-      videos << { video_id: ramdam_data.video_id, title: ramdam_data.title, thumbnail: ramdam_data.thumbnail, view_count: ramdam_data.view_count.to_s(:delimited), published_at: ramdam_data.published_at.strftime("%Y/%m/%d") }
+
+    all_spots.each do |spot|
+      # videoを保有している地点のみ有効
+      if Video.where(spot: spot.name) != []
+        spots << spot
+        areas << spot.country
+        ramdam_data = Video.where(spot: spot.name).order("RANDOM()").first
+        videos << { video_id: ramdam_data.video_id, title: ramdam_data.title, thumbnail: ramdam_data.thumbnail, view_count: ramdam_data.view_count.to_s(:delimited), published_at: ramdam_data.published_at.strftime("%Y/%m/%d") }
+      end
     end
     render json: { spots: spots, areas: areas, videos: videos }
   end

--- a/app/controllers/api/v1/spots_controller.rb
+++ b/app/controllers/api/v1/spots_controller.rb
@@ -10,4 +10,21 @@ class Api::V1::SpotsController < ApiController
       render json: country, status: :bad_request
     end
   end
+
+  # 地点のカウント数(click_count)を+1する
+  def edit
+    spot = Spot.find_by(country_id: params[:country_id], id: params[:id])
+    spot.update(click_count: spot.click_count + 1)
+    render json: { status: 'ok' }
+  end
+
+  # Spotテーブルのすべての地点とその国を返す
+  def all_spot
+    spots = Spot.all.order(click_count: :desc)
+    areas = []
+    spots.each do |spot|
+      areas << spot.country
+    end
+    render json: { spots: spots, areas: areas }
+  end
 end

--- a/app/views/admin/countries/show.html.erb
+++ b/app/views/admin/countries/show.html.erb
@@ -38,10 +38,12 @@
           <thead>
           <tr>
             <th scope="col"><%= Spot.human_attribute_name(:id) %></th>
+            <th scope="col"><%= Country.human_attribute_name(:name) %></th>
             <th scope="col"><%= Spot.human_attribute_name(:name) %></th>
             <th scope="col"><%= Spot.human_attribute_name(:name_ens) %></th>
             <th scope="col"><%= Spot.human_attribute_name(:lat) %></th>
             <th scope="col"><%= Spot.human_attribute_name(:lng) %></th>
+            <th scope="col"><%= Spot.human_attribute_name(:click_count) %></th>
             <th scope="col"></th>
           </tr>
           </thead>

--- a/app/views/admin/spots/_spot.html.erb
+++ b/app/views/admin/spots/_spot.html.erb
@@ -18,6 +18,9 @@
     <%= spot.lng %>
   </td>
   <td>
+    <%= spot.click_count %>
+  </td>
+  <td>
 		<!-- ユーザ詳細画面へのリンク -->
     <%= link_to t('defaults.show'), admin_spot_path(spot), class: 'btn btn-info' %>
 		<!-- ユーザ編集画面へのリンク -->

--- a/app/views/admin/spots/edit.html.erb
+++ b/app/views/admin/spots/edit.html.erb
@@ -27,6 +27,10 @@
           <%= f.label :lng, Spot.human_attribute_name(:lng) %>
           <%= f.text_field :lng, class: 'form-control' %>
         </div>
+        <div class="form-group">
+          <%= f.label :click_count, Spot.human_attribute_name(:click_count) %>
+          <%= f.text_field :click_count, class: 'form-control' %>
+        </div>
         <%= f.submit class: 'btn btn-primary' %>
       <% end %>
     </div>

--- a/app/views/admin/spots/index.html.erb
+++ b/app/views/admin/spots/index.html.erb
@@ -22,6 +22,7 @@
             <th scope="col"><%= Spot.human_attribute_name(:name_ens) %></th>
             <th scope="col"><%= Spot.human_attribute_name(:lat) %></th>
             <th scope="col"><%= Spot.human_attribute_name(:lng) %></th>
+            <th scope="col"><%= Spot.human_attribute_name(:click_count) %></th>
             <th scope="col"></th>
           </tr>
           </thead>

--- a/app/views/admin/spots/show.html.erb
+++ b/app/views/admin/spots/show.html.erb
@@ -34,6 +34,10 @@
           <th scope="row"><%= Spot.human_attribute_name(:lng) %></th>
           <td><%= @spot.lng %></td>
         </tr>
+        <tr>
+          <th scope="row"><%= Spot.human_attribute_name(:click_count) %></th>
+          <td><%= @spot.click_count %></td>
+        </tr>
       </table>
     </div>
   </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -23,21 +23,13 @@ ja:
         name: 国名
         name_ens: 国名(英語表記)
         iso: 国コード
-      prefecture:
-        name: 都道府県名
-        name_ens: 都道府県名(ローマ字表記)
       spot:
         country_id: 国
         name: 地点名
         name_ens: 地点名(英語表記)
         lat: 緯度
         lng: 経度
-      domestic_area:
-        prefecture_id: 都道府県
-        name: 地点名
-        name_ens: 地点名(ローマ字表記)
-        lat: 緯度
-        lng: 経度
+        click_count: クリック数
       video:
         video_id: Youtube動画ID
         area: 国/都道府県

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,6 +1,6 @@
 ja:
   defaults:
-    app_title: WALKTOUR
+    app_title: VtourHub
     logout: ログアウト
     show: 詳細
     new: 新規作成

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :countries, only: %i[index] do
-        resources :spots, only: %i[index], shallow: true
+        resources :spots, only: %i[index edit]
       end
+      get '/all_spot', to: 'spots#all_spot'
       get '/set_country', to: 'countries#set_country'
       get '/many_video', to: 'videos#many_video'
       post '/login', to: 'user_sessions#create'

--- a/db/migrate/20220625035719_create_spots.rb
+++ b/db/migrate/20220625035719_create_spots.rb
@@ -6,6 +6,7 @@ class CreateSpots < ActiveRecord::Migration[6.1]
       t.string :name_ens, null: false, unique: true
       t.decimal :lat,  precision: 11, scale: 8, null: false
       t.decimal :lng, precision: 11, scale: 8, null: false
+      t.integer :click_count, default: 0
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2022_06_27_070750) do
     t.string "name_ens", null: false
     t.decimal "lat", precision: 11, scale: 8, null: false
     t.decimal "lng", precision: 11, scale: 8, null: false
+    t.integer "click_count", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["country_id"], name: "index_spots_on_country_id"


### PR DESCRIPTION
## 実装内容

* 追加：Spotテーブルにカウント数のカラムを追加 https://github.com/O-H-K-N/walk-tour-rails/pull/13/commits/c747998029df65c4059504d17212f9be31b19bf8 
* 追加：Spotテーブルのすべての地点とその国、動画を返すapiを作成 https://github.com/O-H-K-N/walk-tour-rails/pull/13/commits/91f7430046e306a36a8fd3bb0e769215424e2822 
* 修正：すべての地点とその国、動画を返すapiを修正 https://github.com/O-H-K-N/walk-tour-rails/pull/13/commits/d18572bedbc0f74f0bf841e7ec1a6ae345d745b1 